### PR TITLE
feat!: add velcro modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,21 +27,12 @@ Middleware:
 API
 ------------------------------------------------------------------------------
 
-**Middleware**
-
-Options are passed to the included  `middleware` via an argument of the same name:
-
-* `@offset` - see [offset docs](https://floating-ui.com/docs/offset) for expected values
-* `@flip` - see [flip docs](https://floating-ui.com/docs/flip) for expected values
-* `@shift` - see [shift docs](https://floating-ui.com/docs/shift) for expected values
-
-**computePostion**
-
-`computePosition`: takes 3 arguments which can be overridden, or in the case of `middleware`, added to.
-
-* `@placement` - see list of [expected values](https://floating-ui.com/docs/computeposition#placement)
-* `@strategy` - CSS positon property, either 'fixed' or 'absolute'. Pros and cons of each strategy is [here](https://floating-ui.com/docs/computePosition#strategy)
-* `@middleware` - array of any custom [middleware](https://floating-ui.com/docs/middleware) you want to add. The array is spread into the defaults after the `shift` and before the `hide` middleware.
+* `@flipOptions` - see [flip docs](https://floating-ui.com/docs/flip) for option values
+* `@middleware` - array of one or more objects to add to the [middleware](https://floating-ui.com/docs/middleware) array
+* `@offsetOptions` - see [offset docs](https://floating-ui.com/docs/offset) for option values
+* `@placement` - list of [expected values](https://floating-ui.com/docs/computeposition#placement)
+* `@shiftOptions` - see [shift docs](https://floating-ui.com/docs/shift) for option values
+* `@strategy` - CSS position property, either 'fixed' or 'absolute'. Pros and cons of each strategy is [here](https://floating-ui.com/docs/computePosition#strategy)
 
 
 Default values
@@ -49,13 +40,21 @@ Default values
 
 * `@placement`: 'bottom'
 * `@strategy`: 'fixed'
+* `offset`, `flip`, and `shift` middleware all use their defaults.
+* `hide` middleware uses both `referenceHidden` and `escaped` [options](https://floating-ui.com/docs/hide#options).
 
-`offset`, `flip`, and `shift` middleware use their defaults. `hide` middleware uses both `referenceHidden` and `escaped` [options](https://floating-ui.com/docs/hide#options).
-
-Usage
+Usage as Modifier
 ------------------------------------------------------------------------------
 
-Ember Velcro provides a `Velcro` component that yields 3 values; 2 modifiers and 'velcro data':
+```hbs
+<div id="velcro-reference">Velcro reference</div>
+<div {{velcro "#velcro-reference"}}>I'm stuck to Velcro reference!</div>
+```
+
+Usage as Component
+------------------------------------------------------------------------------
+
+The `Velcro` component yields 3 values; 2 modifiers and 'velcro data':
 
 ```hbs
 <Velcro as |velcroReference velcroElement velcroData|>
@@ -96,7 +95,7 @@ ember install github:camskene/ember-velcro
 Contributing
 ------------------------------------------------------------------------------
 
-Ember Velcro is currently written primarily for my own fun and education. I plan to publish to NPM once a half-decent demo site is up.
+Ember Velcro is currently written primarily for my own fun and education.
 
 License
 ------------------------------------------------------------------------------

--- a/addon/components/velcro/index.js
+++ b/addon/components/velcro/index.js
@@ -1,23 +1,14 @@
 import Component from '@glimmer/component';
 import { modifier } from 'ember-modifier';
-import { assert } from '@ember/debug';
 import { tracked } from '@glimmer/tracking';
 
-import {
-  autoUpdate,
-  computePosition,
-  flip,
-  hide,
-  offset,
-  shift,
-} from '@floating-ui/dom';
-
-import { velcroData } from '@camskene/ember-velcro/middleware/velcro-data';
+import VelcroModifier from '@camskene/ember-velcro/modifiers/velcro';
 
 export default class VelcroComponent extends Component {
   _referenceElement = undefined;
 
   @tracked
+  // set by VelcroModifier
   velcroData = undefined;
 
   velcroReference = modifier(
@@ -28,108 +19,21 @@ export default class VelcroComponent extends Component {
   );
 
   velcroElement = modifier(
-    (floatingElement) => {
-      let { _referenceElement } = this;
-
-      assert(
-        'no reference element defined',
-        _referenceElement instanceof HTMLElement
+    (element) => {
+      new VelcroModifier().modify.call(
+        this,
+        element,
+        [this._referenceElement],
+        {
+          flipOptions: this.args.flipOptions,
+          hideOptions: this.args.hideOptions,
+          middleware: this.args.middleware,
+          offsetOptions: this.args.offsetOptions,
+          placement: this.args.placement,
+          shiftOptions: this.args.shiftOptions,
+          strategy: this.args.strategy,
+        }
       );
-
-      assert(
-        'no floating element defined',
-        floatingElement instanceof HTMLElement
-      );
-
-      assert(
-        'reference and floating elements cannot be the same element',
-        floatingElement !== _referenceElement
-      );
-
-      // `update` is passed to `autoUpdate` and is called when necessary so that the floating element
-      // remains "anchored" to the reference element in a variety of scenarios without detaching.
-      let update = async () => {
-        // https://floating-ui.com/docs/computeposition#strategy
-        let strategy = this.args.strategy ?? 'fixed';
-
-        // The layout of the floating element prior to being positioned matters:
-        // * The CSS position must be `absolute` or `fixed` prior to `computePosition()` being called.
-        //   This sets the correct initial dimensions (instead of being `block` layout).
-        // * Setting `top` and `left` to `0` initially minimizes layout interference with the dimensions
-        //   of the element, so that its final dimensions are ready before being positioned.
-        Object.assign(floatingElement.style, {
-          position: strategy,
-          top: '0',
-          left: '0',
-        });
-
-        // https://floating-ui.com/docs/offset#options
-        let offsetOptions = this.args.offset ?? 0;
-
-        // https://floating-ui.com/docs/flip#options
-        let flipMiddleware = this.args.flip ? flip(this.args.flip) : flip();
-
-        // https://floating-ui.com/docs/shift#options
-        let shiftMiddleware = this.args.shift
-          ? shift(this.args.shift)
-          : shift();
-
-        // https://floating-ui.com/docs/middleware
-        // Middleware behavior is dependent on order. Each middleware returns
-        // new coordinates and data which middleware later in the array can use.
-        // In general, `offset()` should always go at the beginning of the middleware
-        // array, while `arrow()` and `hide()` at the end. The other core middleware can
-        // be shifted around depending on the desired behavior.
-        let customMiddleware = this.args.middleware ?? [];
-
-        assert('@middleware must be an array', Array.isArray(customMiddleware));
-
-        let middleware = [
-          offset(offsetOptions),
-          flipMiddleware,
-          shiftMiddleware,
-          ...customMiddleware,
-          hide({ strategy: 'referenceHidden' }),
-          hide({ strategy: 'escaped' }),
-          velcroData(),
-        ];
-
-        // https://floating-ui.com/docs/computePosition#placement
-        let placement = this.args.placement ?? 'bottom';
-
-        let options = {
-          middleware,
-          placement,
-          strategy,
-        };
-
-        // https://floating-ui.com/docs/computePosition
-        let { x, y, middlewareData } = await computePosition(
-          _referenceElement,
-          floatingElement,
-          options
-        );
-
-        x = Math.round(x);
-        y = Math.round(y);
-        let { referenceHidden } = middlewareData.hide;
-
-        Object.assign(floatingElement.style, {
-          transform: `translate3d(${x}px, ${y}px, 0)`,
-          visibility: referenceHidden ? 'hidden' : 'visible',
-        });
-
-        this.velcroData = middlewareData.metadata;
-      };
-
-      // https://floating-ui.com/docs/autoUpdate
-      // `autoUpdate` returns a "cleanup" function that should be invoked when
-      // the floating element is no longer mounted on the DOM.
-      let cleanup = autoUpdate(_referenceElement, floatingElement, update);
-
-      return () => {
-        cleanup();
-      };
     },
     { eager: false }
   );

--- a/addon/modifiers/velcro.js
+++ b/addon/modifiers/velcro.js
@@ -1,0 +1,91 @@
+import Modifier from 'ember-modifier';
+import { assert } from '@ember/debug';
+import { registerDestructor } from '@ember/destroyable';
+
+import {
+  autoUpdate,
+  computePosition,
+  flip,
+  hide,
+  offset,
+  shift,
+} from '@floating-ui/dom';
+
+import { velcroData } from '@camskene/ember-velcro/middleware/velcro-data';
+
+export default class VelcroModifier extends Modifier {
+  modify(
+    floatingElement,
+    [referenceElement],
+    {
+      strategy = 'fixed',
+      offsetOptions = 0,
+      placement = 'bottom',
+      flipOptions,
+      shiftOptions,
+      middleware = [],
+    }
+  ) {
+    if (typeof referenceElement === 'string') {
+      referenceElement = document.querySelector(referenceElement);
+    }
+
+    assert(
+      'no reference element defined',
+      referenceElement instanceof HTMLElement
+    );
+
+    assert(
+      'no floating element defined',
+      floatingElement instanceof HTMLElement
+    );
+
+    assert(
+      'reference and floating elements cannot be the same element',
+      floatingElement !== referenceElement
+    );
+
+    assert(
+      '@middleware must be an array of one or more objects',
+      Array.isArray(middleware)
+    );
+
+    Object.assign(floatingElement.style, {
+      position: strategy,
+      top: '0',
+      left: '0',
+    });
+
+    let update = async () => {
+      let { x, y, middlewareData } = await computePosition(
+        referenceElement,
+        floatingElement,
+        {
+          middleware: [
+            offset(offsetOptions),
+            flip(flipOptions),
+            shift(shiftOptions),
+            ...middleware,
+            hide({ strategy: 'referenceHidden' }),
+            hide({ strategy: 'escaped' }),
+            velcroData(),
+          ],
+          placement,
+          strategy,
+        }
+      );
+
+      Object.assign(floatingElement.style, {
+        strategy,
+        transform: `translate3d(${Math.round(x)}px, ${Math.round(y)}px, 0)`,
+        visibility: middlewareData.hide.referenceHidden ? 'hidden' : 'visible',
+      });
+
+      this.velcroData = middlewareData.metadata;
+    };
+
+    let cleanup = autoUpdate(referenceElement, floatingElement, update);
+
+    registerDestructor(this, cleanup);
+  }
+}

--- a/app/modifiers/velcro.js
+++ b/app/modifiers/velcro.js
@@ -1,0 +1,1 @@
+export { default } from '@camskene/ember-velcro/modifiers/velcro';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@camskene/ember-velcro",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Ember Velcro sticks one element to another with PopperJS.",
   "keywords": [
     "ember-addon"

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,5 +1,10 @@
 {{page-title "Ember Velcro"}}
 
+<p id="reference">Reference</p>
+<p {{velcro "#reference"}}>Floating</p>
+
+<hr>
+
 <Velcro as |velcroTarget velcro|>
   <p {{velcroTarget}}>Velcro target</p>
   <p {{velcro}}>Velcro</p>

--- a/tests/integration/components/velcro-test.js
+++ b/tests/integration/components/velcro-test.js
@@ -140,7 +140,7 @@ module('Integration | Component | velcro', function (hooks) {
             <div {{velcroReference}}>velcroReference</div>
             <div id="velcro1" {{velcro}}>Velcro</div>
           </Velcro>
-          <Velcro @offset={{this.offsetDistance}} @placement="bottom-start" as |velcroReference velcro|>
+          <Velcro @offsetOptions={{this.offsetDistance}} @placement="bottom-start" as |velcroReference velcro|>
             <div {{velcroReference}}>velcroReference</div>
             <div id="velcro2" {{velcro}}>Velcro</div>
           </Velcro>
@@ -168,7 +168,7 @@ module('Integration | Component | velcro', function (hooks) {
           <div {{velcroReference}}>velcroReference</div>
           <div id="velcro1" {{velcro}}>Velcro</div>
         </Velcro>
-        <Velcro @offset={{this.offsetSkidding}} as |velcroReference velcro|>
+        <Velcro @offsetOptions={{this.offsetSkidding}} as |velcroReference velcro|>
           <div {{velcroReference}}>velcroReference</div>
           <div id="velcro2" {{velcro}}>Velcro</div>
         </Velcro>

--- a/tests/integration/components/velcro-test.js
+++ b/tests/integration/components/velcro-test.js
@@ -3,8 +3,14 @@ import { setupRenderingTest } from 'ember-qunit';
 import { find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
+import { resetTestingContainerDimensions } from '../velcro-test-helpers';
+
 module('Integration | Component | velcro', function (hooks) {
   setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    resetTestingContainerDimensions();
+  });
 
   test('it renders', async function (assert) {
     await render(hbs`
@@ -75,7 +81,6 @@ module('Integration | Component | velcro', function (hooks) {
 
   module('@placement', function () {
     test('has default value', async function (assert) {
-      resetTestingContainerDimensions();
       await render(hbs`
         <Velcro as |velcroReference velcroElement velcroData|>
           <div {{velcroReference}}>velcroReference</div>
@@ -87,7 +92,6 @@ module('Integration | Component | velcro', function (hooks) {
     });
 
     test('has argument value', async function (assert) {
-      resetTestingContainerDimensions();
       await render(hbs`
         <Velcro @placement="bottom-start" as |velcroReference velcroElement velcroData|>
           <div {{velcroReference}}>velcroReference</div>
@@ -125,12 +129,10 @@ module('Integration | Component | velcro', function (hooks) {
     });
   });
 
-  module('@offset', function () {
+  module('@offsetOptions', function () {
     test('can pass in distance', async function (assert) {
       let offsetDistance = 10;
       this.set('offsetDistance', offsetDistance);
-
-      resetTestingContainerDimensions();
 
       await render(hbs`
         {{!-- render 2 Velcro's side by side, pass one a distance offset and compare the top values --}}
@@ -160,8 +162,6 @@ module('Integration | Component | velcro', function (hooks) {
       let offsetSkidding = 10;
       this.set('offsetSkidding', { crossAxis: offsetSkidding });
 
-      resetTestingContainerDimensions();
-
       await render(hbs`
         {{!-- render 2 Velcro's atop the other, pass one a skidding offset and compare the left values --}}
         <Velcro as |velcroReference velcro|>
@@ -184,12 +184,3 @@ module('Integration | Component | velcro', function (hooks) {
     });
   });
 });
-
-function resetTestingContainerDimensions() {
-  // reset test container scale so values returned by getBoundingClientRect are accurate
-  Object.assign(document.querySelector('#ember-testing').style, {
-    transform: 'scale(1)',
-    width: '100%',
-    height: '100%',
-  });
-}

--- a/tests/integration/modifiers/velcro-test.js
+++ b/tests/integration/modifiers/velcro-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Modifier | velcro', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    await render(hbs`
+      <div id="reference">Reference</div>
+      <div {{velcro "#reference"}}></div>
+    `);
+
+    assert.ok(true);
+  });
+});

--- a/tests/integration/modifiers/velcro-test.js
+++ b/tests/integration/modifiers/velcro-test.js
@@ -1,10 +1,19 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { set } from '@ember/object';
+import {
+  addDataAttributes,
+  resetTestingContainerDimensions,
+} from '../velcro-test-helpers';
 
 module('Integration | Modifier | velcro', function (hooks) {
   setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    resetTestingContainerDimensions();
+  });
 
   test('it renders', async function (assert) {
     await render(hbs`
@@ -13,5 +22,102 @@ module('Integration | Modifier | velcro', function (hooks) {
     `);
 
     assert.ok(true);
+  });
+
+  module('@placement', function () {
+    set(this, 'addDataAttributes', addDataAttributes());
+    test('has default value', async function (assert) {
+      await render(hbs`
+        <div id="velcro-reference">Velcro reference</div>
+        <div id="velcro" {{velcro "#velcro-reference" middleware=(array this.addDataAttributes)}}>Velcro</div>
+      `);
+
+      assert.dom('#velcro ').hasAttribute('data-placement', 'bottom');
+    });
+
+    test('has named argument value', async function (assert) {
+      await render(hbs`
+        <div id="velcro-reference">Velcro reference</div>
+        <div id="velcro" {{velcro "#velcro-reference" placement="bottom-start" middleware=(array this.addDataAttributes)}}>Velcro</div>
+      `);
+
+      assert.dom('#velcro ').hasAttribute('data-placement', 'bottom-start');
+    });
+  });
+
+  module('@strategy', function () {
+    set(this, 'addDataAttributes', addDataAttributes());
+    test('has default value', async function (assert) {
+      await render(hbs`
+        <div id="velcro-reference">Velcro reference</div>
+        <div id="velcro" {{velcro "#velcro-reference" middleware=(array this.addDataAttributes)}}>Velcro</div>
+      `);
+
+      assert.dom('#velcro ').hasAttribute('data-strategy', 'fixed');
+    });
+
+    test('has named argument value', async function (assert) {
+      await render(hbs`
+        <div id="velcro-reference">Velcro reference</div>
+        <div id="velcro" {{velcro "#velcro-reference" strategy="absolute" middleware=(array this.addDataAttributes)}}>Velcro</div>
+      `);
+
+      assert.dom('#velcro ').hasAttribute('data-strategy', 'absolute');
+    });
+  });
+
+  module('@offsetOptions', function () {
+    test('can pass in distance', async function (assert) {
+      let offsetDistance = 10;
+      set(this, 'offsetDistance', offsetDistance);
+
+      await render(hbs`
+        {{!-- render 2 Velcro's side by side, pass one a distance offset and compare the top values --}}
+        {{!-- template-lint-disable no-inline-styles --}}
+        <div style="display: flex">
+          <div>
+            <div id="velcro-reference">Velcro reference</div>
+            <div id="velcro1" {{velcro "#velcro-reference"}}>Velcro</div>
+          </div>
+          <div>
+            <div>velcroReference</div>
+            <div id="velcro2" {{velcro "#velcro-reference" offsetOptions=this.offsetDistance placement="bottom-start"}}>Velcro</div>
+          </div>
+        </div>
+      `);
+
+      let velcro1 = find('#velcro1');
+      let velcro2 = find('#velcro2');
+
+      assert.strictEqual(
+        velcro1.getBoundingClientRect().top + offsetDistance,
+        velcro2.getBoundingClientRect().top
+      );
+    });
+
+    test('can pass in skidding', async function (assert) {
+      let offsetSkidding = 10;
+      set(this, 'offsetSkidding', { crossAxis: offsetSkidding });
+
+      await render(hbs`
+        {{!-- render 2 Velcro's atop the other, pass one a skidding offset and compare the left values --}}
+        <div>
+          <div id="velcro-reference">Velcro reference</div>
+          <div id="velcro1" {{velcro "#velcro-reference"}}>Velcro</div>
+        </div>
+        <div>
+          <div id="velcro-reference">velcroReference</div>
+          <div id="velcro2" {{velcro "#velcro-reference" offsetOptions=this.offsetSkidding}}>Velcro</div>
+        </div>
+      `);
+
+      let velcro1 = find('#velcro1');
+      let velcro2 = find('#velcro2');
+
+      assert.strictEqual(
+        velcro1.getBoundingClientRect().left + offsetSkidding,
+        velcro2.getBoundingClientRect().left
+      );
+    });
   });
 });

--- a/tests/integration/velcro-test-helpers.js
+++ b/tests/integration/velcro-test-helpers.js
@@ -1,0 +1,24 @@
+// Floating UI middleware
+// provides data-* attributes for values in test assertions
+export function addDataAttributes() {
+  return {
+    name: 'dataAttributes',
+    fn: ({ elements, placement, strategy }) => {
+      elements.floating.setAttribute('data-placement', placement);
+      elements.floating.setAttribute('data-strategy', strategy);
+
+      // https://floating-ui.com/docs/middleware#always-return-an-object
+      return {};
+    },
+  };
+}
+
+// testing containers transforms give Floating UI's logic some challenges
+export function resetTestingContainerDimensions() {
+  // reset test container scale so values returned by getBoundingClientRect are accurate
+  Object.assign(document.querySelector('#ember-testing').style, {
+    transform: 'scale(1)',
+    width: '100%',
+    height: '100%',
+  });
+}


### PR DESCRIPTION
Ember Velcro can now be used as a modifier as well as a component.

BREAKING CHANGE: arguments to middleware are now composed of the middleware name + 'Options'.

eg `@offset` -> `@offsetOptions`